### PR TITLE
changed versioning logic through go generate & go embed

### DIFF
--- a/.github/workflows/aur.yaml
+++ b/.github/workflows/aur.yaml
@@ -1,9 +1,10 @@
 name: Publish package to AUR
 
 on:
-  push:
-    tags:
-      - "*"
+  workflow_run:
+    workflows: ["Update package version"]
+    branches: ["master"]
+    types: ["completed"]
 
 jobs:
   publish-to-aur:
@@ -12,24 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
-        with:
-          strip_v: true
-
-      - name: Create AUR PKGBUILD
-        run: |
-          mkdir aur-package && cd aur-package
-          cp ../template/archlinux/PKGBUILD .
-          sed -i "s|__VERSION__|${{ steps.tag.outputs.tag }}|g" PKGBUILD
-
       - name: Publish to the AUR
         uses: KSXGitHub/github-actions-deploy-aur@v2.2.5
         with:
           pkgname: go-translation-git
-          pkgbuild: ./aur-package/PKGBUILD
+          pkgbuild: ./template/archlinux/PKGBUILD
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
-          commit_message: "Version ${{ steps.tag.outputs.tag }}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,13 +1,15 @@
 name: Deploy docker image
 
 on:
-  push:
-    tags:
-      - "*"
+  workflow_run:
+    workflows: ["Update package version"]
+    branches: ["master"]
+    types: ["completed"]
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  ACTOR: ${{ github.actor }}
 
 jobs:
   build-and-push-image:
@@ -24,19 +26,12 @@ jobs:
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          username: ${{ env.ACTOR }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ env.ACTOR }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,12 +10,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.18
-      - name: build cli
+
+      - name: Build cli
         run: make
-      - name: testing translator package
+
+      - name: Testing translator package
         run: cd ./pkg/translator && go test -v

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,32 @@
+name: Update package version
+
+on:
+  push:
+    branches: ['*']
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
+      - name: Generate version
+        run: go generate ./...
+
+      - name: Update AUR PKGBUILD
+        run: |
+          version=$(cat ./cmd/got/.version)
+          sed -i "s|^pkgver=.*|pkgver=$version|" ./template/archlinux/PKGBUILD
+
+      - name: Commit and push changes
+        uses: devops-infra/action-commit-push@v0.9.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          amend: true
+          no_edit: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.18-alpine AS builder
 WORKDIR /app
 COPY . /app
-RUN go build -ldflags "-X main.gotVersion=0.1" -o got /app/cmd/got/main.go
+RUN go generate ./...
+RUN go build -o got /app/cmd/got/main.go
 
 FROM alpine:3.15
 COPY --from=builder /app/got /

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all:
-	go build -ldflags "-X main.gotVersion=0.1" -o got cmd/got/main.go
+	go generate ./...
+	go build -o got cmd/got/main.go
 
 run:
 	go run cmd/got/main.go
@@ -16,7 +17,8 @@ docker-run:
 	docker run -it -e "TERM=xterm-256color" got
 
 install:
-	go build -ldflags "-X main.gotVersion=0.1" -o got cmd/got/main.go
+	go generate ./...
+	go build -o got cmd/got/main.go
 	mv -f got `go env GOPATH`/bin/
 
 uninstall:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # got
-[![GO](https://github.com/fedeztk/got/actions/workflows/go.yaml/badge.svg)](https://github.com/fedeztk/got/tree/master/.github/workflows/go.yml) [![GHCR](https://github.com/fedeztk/got/actions/workflows/deploy.yaml/badge.svg)](https://github.com/fedeztk/got/tree/release/.github/workflows/deploy.yml) [![AUR](https://img.shields.io/aur/version/go-translation-git)](https://aur.archlinux.org/packages/go-translation-git)
+[![GO](https://github.com/fedeztk/got/actions/workflows/go.yaml/badge.svg)](https://github.com/fedeztk/got/tree/master/.github/workflows/go.yml) [![GHCR](https://github.com/fedeztk/got/actions/workflows/deploy.yaml/badge.svg)](https://github.com/fedeztk/got/tree/release/.github/workflows/deploy.yml) [![AUR](https://img.shields.io/aur/version/go-translation-git?logo=archlinux)](https://aur.archlinux.org/packages/go-translation-git)
 
 ## Table of Contents
 

--- a/cmd/got/get_version.sh
+++ b/cmd/got/get_version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)" > .version

--- a/cmd/got/main.go
+++ b/cmd/got/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"flag"
 	"fmt"
 	"os"
@@ -11,9 +12,9 @@ import (
 	"github.com/fedeztk/got/pkg/translator"
 )
 
-var (
-	gotVersion string
-)
+//go:generate ./get_version.sh
+//go:embed .version
+var gotVersion string
 
 func main() {
 	showVersion := flag.Bool(

--- a/template/archlinux/PKGBUILD
+++ b/template/archlinux/PKGBUILD
@@ -22,7 +22,7 @@ build() {
 	export CGO_CXXFLAGS="${CXXFLAGS}"
 	export CGO_LDFLAGS="${LDFLAGS}"
 	export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
-	go build -ldflags "-X main.gotVersion=$pkgver" -o got ./cmd/got/main.go
+	go build -o got ./cmd/got/main.go
 }
 
 package() {


### PR DESCRIPTION
Now all version follow the git revision logic:
```sh
printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
```
A gh action update a file (.version) with the content of the above `printf`. It is then embedded in the go binary.
This change aims to reach consistency and ease of use in `got`'s versioning by unifying the standard way of git packaging version in arch linux together with `go install`, `make`, `docker` etc.
