### PR TITLE
consinstency in naming flags/parameters for interactive and oneshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ got -e reverso # change engine to reverso
 ```
 -  Or in oneshot mode:
 ```sh
-got -o -f en -t it "Hello World"          # use default (google)
-got -o -e libre -f en -t it "Hello World" # use libre-translate
+got -o -s en -t it "Hello World"          # use default (google)
+got -o -e libre -s en -t it "Hello World" # use libre-translate
 ```
 For more information check the help (`got -h`)
 <a id="org26baa6c"></a>

--- a/cmd/got/main.go
+++ b/cmd/got/main.go
@@ -25,14 +25,14 @@ func main() {
 	oneShot := flag.Bool(
 		"o",
 		false,
-		"one shot mode, requires -f and -t",
+		"one shot mode, requires -s and -t",
 	)
-	from := flag.String(
-		"f",
+	source := flag.String(
+		"s",
 		"",
 		"language to translate from",
 	)
-	to := flag.String(
+	target := flag.String(
 		"t",
 		"",
 		"language to translate to",
@@ -49,14 +49,14 @@ func main() {
 		fmt.Println(gotVersion)
 
 	case *oneShot:
-		if *from == "" || *to == "" {
-			fmt.Println("from and to are required in one shot mode")
+		if *source == "" || *target == "" {
+			fmt.Println("source and target are required in one shot mode")
 			os.Exit(1)
 		}
 		if *engine == "" {
 			*engine = "google"
 		}
-		response, err := translator.Translate(strings.Join(flag.Args(), " "), *from, *to, *engine)
+		response, err := translator.Translate(strings.Join(flag.Args(), " "), *source, *target, *engine)
 		if err != nil {
 			fmt.Println(model.ErrorStyle.Render(err.Error()))
 			os.Exit(1)


### PR DESCRIPTION
# Warning
This merge break `-f` flag in order to adhere to a more consistent naming convention. Now both the TUI and the oneshot mode work with the same keybindings/flags. Prior to this update you would select the source language with `s` in the TUI and with `-f` in the non-interactive mode (oneshot). Now both use `s` and `-s` respectively.